### PR TITLE
Fix: user.jsonが0件の時、登録処理でエラーになる問題を修正

### DIFF
--- a/Ex05/Models/UserDao.cs
+++ b/Ex05/Models/UserDao.cs
@@ -31,8 +31,12 @@ namespace MyApp.Namespace
             using (var reader = new FileStream(this.source, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             using (var writer = new FileStream(this.source, FileMode.Open, FileAccess.Write, FileShare.ReadWrite)) {
                 var list = JsonSerializer.Deserialize<List<UserData>>(reader);
-                userData.No = (list.Max(x => x.No) + 1);
-                list.Add(userData);
+                if(list == null || list.Count == 0){
+		    userData.No = 1;
+		}else{
+		    userData.No = (list.Max(x => x.No) + 1);
+		}
+		list.Add(userData);
                 writer.SetLength(0);
                 JsonSerializer.Serialize(writer, list);
             };


### PR DESCRIPTION
1. Ex05\Models\Datas\user.jsonを空にする、もしくは画面から全てユーザデータを削除する
2. 画面からユーザを新規登録する
3. 登録ボタン押下時、user.jsonが空な為、Maxプロパティでエラー

上記の処理について修正しました。